### PR TITLE
記事個別のdescriptionとkeywordを設定できるように修正する

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -42,8 +42,11 @@
     {{- if or (eq .Params.type "search_result") (eq .Params.nolink true) }}
     <meta name="robots" content="noindex">
     {{- end }}
+    {{- if .Description }}
     <meta name="description" content="{{.Description}}">
-    <meta name="keywords" content="{{ delimit .Keywords ", " }}">
+    {{- else }}
+    <meta name="description" content="{{$desc}}">
+    {{- end }}
     <meta name="thumbnail" content="https://{{.Site.Params.domain}}{{ .Site.Params.og_img | relURL }}">
     <meta property="og:url" content="https://{{.Site.Params.domain}}{{.Permalink | relURL }}">
     {{- if .IsHome}}
@@ -54,7 +57,11 @@
     <meta property="og:site_name" content="{{$sitename}}">
     <meta property="og:title" content="{{$title}}">
     <meta property="og:image" content="https://{{.Site.Params.domain}}{{ .Site.Params.og_img | relURL }}">
+    {{- if .Description }}
     <meta property="og:description" content="{{.Description}}">
+    {{- else }}
+    <meta property="og:description" content="{{$desc}}">
+    {{- end }}
     <meta property="og:locale" content="{{.Site.LanguageCode}}">
     <meta name="apple-mobile-web-app-title" content="{{$title}}">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -42,7 +42,8 @@
     {{- if or (eq .Params.type "search_result") (eq .Params.nolink true) }}
     <meta name="robots" content="noindex">
     {{- end }}
-    <meta name="description" content="{{$desc}}">
+    <meta name="description" content="{{.Description}}">
+    <meta name="keywords" content="{{ delimit .Keywords ", " }}">
     <meta name="thumbnail" content="https://{{.Site.Params.domain}}{{ .Site.Params.og_img | relURL }}">
     <meta property="og:url" content="https://{{.Site.Params.domain}}{{.Permalink | relURL }}">
     {{- if .IsHome}}
@@ -53,7 +54,7 @@
     <meta property="og:site_name" content="{{$sitename}}">
     <meta property="og:title" content="{{$title}}">
     <meta property="og:image" content="https://{{.Site.Params.domain}}{{ .Site.Params.og_img | relURL }}">
-    <meta property="og:description" content="{{$desc}}">
+    <meta property="og:description" content="{{.Description}}">
     <meta property="og:locale" content="{{.Site.LanguageCode}}">
     <meta name="apple-mobile-web-app-title" content="{{$title}}">
     <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
ヘルプ記事のMDファイル側にdescriptionとkeywordsを設定すると、metaタグに反映してくれる。

設定
```
---
title: パッケージ製品からのデータ移行
weight: 900
keywords: "word1, word2, word3"
description: パッケージ製品からcybozu.comへデータを移行する手順を説明する記事です。
---
```

出力例
```
<meta name="description" content="記事個別の説明を書く">
<meta name="keywords" content="word1,, word2,, word3">
<meta property="og:description" content="パッケージ製品からcybozu.comへデータを移行する手順を説明する記事です。">
```
