### PR TITLE
単独で使える.step-sectionを追加する

### DIFF
--- a/layouts/shortcodes/proc1.html
+++ b/layouts/shortcodes/proc1.html
@@ -1,0 +1,1 @@
+<span class="proc1">{{ .Inner | markdownify }}</span>

--- a/layouts/shortcodes/proc2.html
+++ b/layouts/shortcodes/proc2.html
@@ -1,0 +1,1 @@
+<span class="proc2">{{ .Inner | markdownify }}</span>

--- a/static/stylesheets/application.css
+++ b/static/stylesheets/application.css
@@ -949,11 +949,10 @@ ul.breadcrumbs {
     padding-bottom: 150px;
 }
 
-.proc1 {
+.proc1,.proc2 {
     margin:0 4px 0 0;
     padding:4px 8px;
     color:#FFF;
-    background-color: #00823B;
     display:inline-block;
     border-radius: 5px;
     -webkit-border-radius: 5px;
@@ -961,16 +960,12 @@ ul.breadcrumbs {
     font-weight:bold;
 }
 
+.proc1 {
+    background-color: #00823B;
+}
+
 .proc2 {
-    margin:0 4px 0 0;
-    padding:4px 8px;
-    color:#FFF;
     background-color: #4169e1;
-    display:inline-block;
-    border-radius: 5px;
-    -webkit-border-radius: 5px;
-    -moz-border-radius: 5px;
-    font-weight:bold;
 }
 
 /* -------------------- end of Article */

--- a/static/stylesheets/application.css
+++ b/static/stylesheets/application.css
@@ -948,6 +948,31 @@ ul.breadcrumbs {
 .home-article {
     padding-bottom: 150px;
 }
+
+.proc1 {
+    margin:0 4px 0 0;
+    padding:4px 8px;
+    color:#FFF;
+    background-color: #00823B;
+    display:inline-block;
+    border-radius: 5px;
+    -webkit-border-radius: 5px;
+    -moz-border-radius: 5px;
+    font-weight:bold;
+}
+
+.proc2 {
+    margin:0 4px 0 0;
+    padding:4px 8px;
+    color:#FFF;
+    background-color: #4169e1;
+    display:inline-block;
+    border-radius: 5px;
+    -webkit-border-radius: 5px;
+    -moz-border-radius: 5px;
+    font-weight:bold;
+}
+
 /* -------------------- end of Article */
 
 


### PR DESCRIPTION
操作者が2名、交互に出現する手順説明で使うspanをshortcodeに追加したい。


例）[サイボウズドットコム ストア管理者の追加方法](https://jp.cybozu.help/general/ja/store/settings/add_admin.html#settings_add_admin_30)

<img width="757" alt="スクリーンショット 2021-08-29 22 16 59" src="https://user-images.githubusercontent.com/38411001/131251714-183bd1d7-352a-40bb-ab13-5241cd397ef8.png">


以下のように使用する。

```
1. {{% proc1 %}}既存の管理者の操作{{% /proc1 %}}招待メールを送信します。
2. {{% proc2 %}}招待された人の操作{{% /proc2 %}}招待メールを受信します。
```

必要に応じて、custom_general.cssなど、個別のCSSでオーバーライドして背景色やフォントを変更する想定。