### PR TITLE
helpmanage-769 Slash の h6 と Definitions List の余白をいい感じにする

### DIFF
--- a/static/stylesheets/custom_general.css
+++ b/static/stylesheets/custom_general.css
@@ -43,6 +43,10 @@
   font-weight: bold;
 }
 
+.article dl > dt:nth-child(n + 2) {
+  margin-top: 14px;
+}
+
 .article dd {
   margin-bottom: 7px;
   padding-left: 20px;

--- a/static/stylesheets/custom_general.css
+++ b/static/stylesheets/custom_general.css
@@ -34,6 +34,10 @@
     padding-top: 0px;
 }
 
+:not(div.id-link-message) + .h6-noanc {
+  margin-top: 24px;
+}
+
 .article dl {
   margin: 5px;
 }


### PR DESCRIPTION
[helpmanage-769](https://bozuman.cybozu.com/k/35488/show#record=769)

## h6

テキストのみ http://localhost:1313/general/ja/admin/support.html
画像がある http://localhost:1313/general/ja/admin/administration_screen.html
箇条書きがある http://localhost:1313/general/ja/admin/list_security/list_login/pw_allow.html

## Definitions List

テキスト1行のみ http://localhost:1313/general/ja/admin/outbound_ipaddress.html
テキストが複数行ある http://localhost:1313/general/ja/admin/list_saml/saml_errors.html
dd が2行ある http://localhost:1313/general/ja/admin/list_useradmin/list_user/modify/name.html