### PR TITLE
helpmanage-888 Slash(JP/CN)でも、サイトロゴを文字で表示したい

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,10 +24,6 @@
                         <img class="logo-img" src="{{ $.Site.BaseURL }}{{.}}" alt="{{$alt}}" title="{{$alt}}" aria-hidden="{{$hidden}}">
             {{- end -}}
             {{- $title := printf "%s %s" ($.Scratch.Get "sitename") $.Site.Params.help -}}
-            
-            {{- if eq .Site.Params.product "slash" -}}
-                {{- $title = printf " %s" $.Site.Params.help -}}
-            {{- end -}}
                         <span class="logo-title">{{$title}}</span>
                     </a>
                 </h1>


### PR DESCRIPTION
[helpmanage-888](https://bozuman.cybozu.com/k/35488/show#record=888)
Slash ではグロナビのロゴに画像を使っているので、「画像 ヘルプ」と表示されるように分岐を入れていた
アクセシビリティの観点で、画像と文字を組み合わせる場合、読み上げソフトで意図通りに読んでもらうのは難しい。
他の製品ヘルプのように、文字に寄せたいので、この分岐をなくす。