### PR TITLE
feat: コードブロックの内容をコピーするボタン

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -103,6 +103,12 @@ other = "Copy the permanent link."
 [Link_was_copied]
 other = "The permanent link has been copied."
 
+[Copy_codeblock_button]
+other = "Copy"
+
+[Codeblock_was_copied]
+other = "The content has been copied."
+
 [Help_site]
 other = "Help Site"
 

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -103,6 +103,12 @@ other = "固定リンクをコピーします"
 [Link_was_copied]
 other = "固定リンクがコピーされました"
 
+[Copy_codeblock_button]
+other = "コピー"
+
+[Codeblock_was_copied]
+other = "コピーされました"
+
 [Help_site]
 other = "ヘルプサイト"
 

--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -105,6 +105,12 @@ other = "複製鏈接"
 [Link_was_copied]
 other = "鏈接已復制"
 
+[Copy_codeblock_button]
+other = "複製"
+
+[Codeblock_was_copied]
+other = "內容已復制"
+
 [Help_site]
 other = "說明網站"
 

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -103,6 +103,12 @@ other = "复制固定链接"
 [Link_was_copied]
 other = "固定链接已复制"
 
+[Copy_codeblock_button]
+other = "复制"
+
+[Codeblock_was_copied]
+other = "内容已复制"
+
 [Help_site]
 other = "帮助网站"
 

--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,0 +1,11 @@
+<div class="codeblock-wrapper">
+  {{- if .Attributes.copy }}
+    <button class="codeblock-copy-button" title="{{ i18n "Copy_codeblock_button" }}">
+      <i class="fas fa-copy" aria-hidden="true"></i>{{ i18n "Copy_codeblock_button" }}
+    </button>
+    <div class="codeblock-copy-message">{{ i18n "Codeblock_was_copied" }}</div>
+  {{- end -}}
+  <div class="codeblock--content">
+    {{- highlight ( .Inner | safeHTML ) .Type .Options }}
+  </div>
+</div>

--- a/static/javascripts/application.js
+++ b/static/javascripts/application.js
@@ -908,6 +908,33 @@
             });
         }
 
+        // コードブロックのコピーボタン
+        if($('.codeblock-copy-button').length > 0) {
+            $('.codeblock-copy-button').click(function() {
+                const codeblockContent = $('.codeblock--content');
+                if(!codeblockContent) {
+                    return;
+                }
+                let cpdflg = false;
+                // text() を使うと末尾に2つスペースが入るので除去する
+                const text = codeblockContent.text().replace(/  $/g,'');
+                if(navigator.clipboard){
+                    navigator.clipboard.writeText(text);
+                    cpdflg = true;
+                } else if(window.clipboardData){
+                    // for IE
+                    window.clipboardData.setData("Text" , text);
+                    cpdflg = true;
+                }
+                if (cpdflg) {
+                    const msg = $(this).next(".codeblock-copy-message");
+                    if(msg) {
+                        msg.show();
+                        msg.fadeOut(3000);
+                    }
+                }
+            });
+        }
     /*** ステップリストのチェックボックス ***/
 
         // ステップ索引

--- a/static/stylesheets/application.css
+++ b/static/stylesheets/application.css
@@ -2298,7 +2298,7 @@ i.index-pdf {
 
 /* for print out */
 @media print {
-    nav, header, footer, iframe, #enquete, #tree-nav, #goto-top, .id-headding-button, .id-link-button, .id-bar, .step-list-check, .step-check {
+    nav, header, footer, iframe, #enquete, #tree-nav, #goto-top, .id-headding-button, .id-link-button, .id-bar, .step-list-check, .step-check, .codeblock-copy-button {
         display: none !important;
     }
     .step-index {

--- a/static/stylesheets/application.css
+++ b/static/stylesheets/application.css
@@ -718,6 +718,37 @@ h6 + .id-link-button {
     z-index: 999;
 }
 
+
+.codeblock-wrapper {
+    position: relative;
+}
+
+.codeblock-copy-button {
+    display: block;
+    position: absolute;
+    right: 4px;
+    top: 4px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    background-color: #fff;
+}
+
+.codeblock-copy-button:hover {
+    background-color: #ECEAF7;
+}
+
+.codeblock-copy-message {
+    display: none;
+    position: absolute;
+    right: 0;
+    top: 48px;
+    padding: .5em;
+    color: #fff;
+    background-color: rgba(29,30,29,0.8);
+    z-index: 999;
+}
+
 /* tree navigation -------------------- */
 .tree-wrap {
     height: 100%;


### PR DESCRIPTION
[HUGO v0.93.0](https://github.com/gohugoio/hugo/releases/tag/v0.93.0) の機能を使って、コピーボタンを実装する

````markdown
```csv {copy=true}
"ログイン名","サービスコード1","サービスコード2","サービスコード3"
"takahashi","ki","gr","sa"
"kato","ki","sa","",""
"suzuki","gr","",""
```
```` 
のように、`copy=true` を渡すと、コピーボタンがでて内容をコピーできる。

![Kapture 2022-04-26 at 07 50 12](https://user-images.githubusercontent.com/14119304/165189031-8bce5348-3980-4a4e-8d41-5fdcd85a1184.gif)
