### PR TITLE
helpmanage-903 箇条書き内の p タグの上下マージンが効かない

### DIFF
--- a/static/stylesheets/custom_general.css
+++ b/static/stylesheets/custom_general.css
@@ -24,6 +24,10 @@
     margin-bottom: 40px;
 }
 
+.article li p + ul {
+    margin-top: .9em;
+}
+
 .article ul li {
     margin-bottom: 7px;
 }


### PR DESCRIPTION
https://github.com/CybozuDocs/hugo-template/blob/master/static/stylesheets/application.css#L1005
箇条書きの中の p タグに、display: inline 属性がついていて、p タグ上下のマージンが効かなくなっている。
そのため、箇条書き内の p タグと、それに続く要素のマージンのマージンが無い状態になる。

例：
https://help.cybozu.com/general/ja/admin/list_security/list_login/account_lock.html の 手順 4. note 
![ 2022-04-28 10 30 22](https://user-images.githubusercontent.com/14119304/165658342-42e6931a-b570-4845-a0b6-b364cb593f67.png)


`display: inline-block` にすれば、上下マージンが効くようになるが、影響範囲が広そう。
いったんは、あとに ul が続いたときだけマージンを入れるようにする。
マージン量は p タグの margin-bottom の量と同じ。
![ 2022-04-28 10 52 09](https://user-images.githubusercontent.com/14119304/165660478-4a50f9c1-b81d-458e-ac18-763e44e688a5.png)


