### PR TITLE
タブレットで表示したときにwelcomeメッセージが背景画像に被らないようにする

### DIFF
--- a/static/stylesheets/custom_general.css
+++ b/static/stylesheets/custom_general.css
@@ -107,4 +107,13 @@
         padding-top: 0;
         font-size: 18px;
     }
+
+    .main {
+        top: 0px;
+    }
+
+    .hero {
+        height: 180px;
+  }
+
 }


### PR DESCRIPTION
![ 2022-07-21 16 25 40](https://user-images.githubusercontent.com/14119304/180335849-1b51a12a-1e7b-4024-b62b-37fbb66bc627.png)
↓
![ 2022-07-22 9 18 50](https://user-images.githubusercontent.com/14119304/180335912-250c9330-2091-43c4-865a-caac61b1a2ff.png)

