### PR TITLE
コードブロックに隣接するpタグのつまりを解消する

### DIFF
--- a/static/stylesheets/custom_general.css
+++ b/static/stylesheets/custom_general.css
@@ -95,6 +95,11 @@
   margin-left: 4em;
 }
 
+/* コードブロックで利用する設定 ********************************************/
+.codeblock-wrapper + p {
+  margin-top: 0.9em;
+}
+
 /* 768px以上の設定 *****************************************************/
 @media only screen and (min-width:768px){
     .logo-img {


### PR DESCRIPTION
コードブロックに隣接する p タグの上の余白が狭い。
他のタグも同じ現象が発生すると思われるが、現時点では p タグだけなので p タグだけやる。
余白サイズは、p タグの bottom に合わせる