### PR TITLE
TcTodo-245 shortcodeの互換設定を削除する

### DIFF
--- a/layouts/partials/applyparams.html
+++ b/layouts/partials/applyparams.html
@@ -11,4 +11,15 @@
 {{- $t9 := replaceRE "{{%\\s*service_type\\s*%}}" $params.service_type $t8 }}
 {{- $t10 := replaceRE "{{%\\s*help\\s*%}}" $params.help $t9 }}
 {{- $t11 := replaceRE "{{%\\s*product_name\\s*%}}" $params.product_name $t10 }}
-{{- return $t11 }}
+{{- $t12 := replaceRE "{{<\\s*kintone\\s*>}}" $params.kintone $t11  }}
+{{- $t13 := replaceRE "{{<\\s*service\\s*>}}" $params.service $t12 }}
+{{- $t14 := replaceRE "{{<\\s*store\\s*>}}" $params.store $t13 }}
+{{- $t15 := replaceRE "{{<\\s*cybozu_com\\s*>}}" $params.cybozu_com $t14 }}
+{{- $t16 := replaceRE "{{<\\s*slash_help\\s*>}}" $params.slash_help $t15 }}
+{{- $t17 := replaceRE "{{<\\s*slash\\s*>}}" $params.slash $t16 }}
+{{- $t18 := replaceRE "{{<\\s*CorpName\\s*>}}" $params.CorpName $t17 }}
+{{- $t19 := replaceRE "{{<\\s*product\\s*>}}" $params.product $t18 }}
+{{- $t20 := replaceRE "{{<\\s*service_type\\s*>}}" $params.service_type $t19 }}
+{{- $t21 := replaceRE "{{<\\s*help\\s*>}}" $params.help $t20 }}
+{{- $t22 := replaceRE "{{<\\s*product_name\\s*>}}" $params.product_name $t21 }}
+{{- return $t22 }}

--- a/layouts/shortcodes/anchorstep.html
+++ b/layouts/shortcodes/anchorstep.html
@@ -1,4 +1,3 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 {{- $id := "" }}
 {{- if .Get "id" }}
     {{- $id = .Get "id" }}

--- a/layouts/shortcodes/anchorstep2.html
+++ b/layouts/shortcodes/anchorstep2.html
@@ -1,4 +1,3 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 {{- $id := "" }}
 {{- if .Get "id" }}
     {{- $id = .Get "id" }}

--- a/layouts/shortcodes/disabled.html
+++ b/layouts/shortcodes/disabled.html
@@ -1,5 +1,4 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 {{- if in .Params $.Site.Params.TargetRegion}}
 {{else}}
-{{- .Inner}}
+{{- .Inner | .Page.RenderString }}
 {{- end}}

--- a/layouts/shortcodes/enabled.html
+++ b/layouts/shortcodes/enabled.html
@@ -1,4 +1,3 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 {{- if in .Params $.Site.Params.TargetRegion}}
-{{- .Inner}}
+{{- .Inner | .Page.RenderString }}
 {{- end}}

--- a/layouts/shortcodes/graynote2.html
+++ b/layouts/shortcodes/graynote2.html
@@ -1,2 +1,1 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 <div class="graynote">{{ .Inner | markdownify }}</div>

--- a/layouts/shortcodes/hint.html
+++ b/layouts/shortcodes/hint.html
@@ -1,4 +1,3 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 <aside class="admonition hint">
   <div class="admonition-alt">
 {{- if and (ne .Site.Params.product "Garoon") (ne .Site.Params.product "Mailwise") (ne .Site.Params.product "Office") }}

--- a/layouts/shortcodes/listtext.html
+++ b/layouts/shortcodes/listtext.html
@@ -1,4 +1,3 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 <div class="listtext">
 {{ .Inner | markdownify }}
 </div>

--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -1,4 +1,3 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 <aside class="admonition note">
   <div class="admonition-alt">
 {{- if and (ne .Site.Params.product "Garoon") (ne .Site.Params.product "Mailwise") (ne .Site.Params.product "Office") }}

--- a/layouts/shortcodes/reference.html
+++ b/layouts/shortcodes/reference.html
@@ -1,4 +1,3 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 <aside class="admonition reference">
   <div class="admonition-alt">
     <i class="fas fa-info-circle fa-fw" aria-hidden="true"></i>

--- a/layouts/shortcodes/seealso.html
+++ b/layouts/shortcodes/seealso.html
@@ -1,4 +1,3 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 <aside class="referrence">
 <h1>{{- .Get "title" -}}</h1>
 {{ printf "%s" .Inner | markdownify }}

--- a/layouts/shortcodes/tile.html
+++ b/layouts/shortcodes/tile.html
@@ -1,4 +1,3 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 <div class="col-tile">
     {{- .Scratch.Set "target" "_self" -}}
     {{- if eq (.Get "external") "true" -}}

--- a/layouts/shortcodes/tile2.html
+++ b/layouts/shortcodes/tile2.html
@@ -1,4 +1,3 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 {{- $tmptitle_pref := "<div class=\"tmp-tile-title\">" }}
 {{- $tmptitle := printf "%s(.|\n)*?</div>" $tmptitle_pref }}
 {{- $div_title := findRE $tmptitle .Inner }}

--- a/layouts/shortcodes/tile_img.html
+++ b/layouts/shortcodes/tile_img.html
@@ -1,4 +1,3 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 <div class="col-tile">
     {{- .Scratch.Set "target" "_self" -}}
     {{- if eq (.Get "external") "true" -}}

--- a/layouts/shortcodes/tile_img2.html
+++ b/layouts/shortcodes/tile_img2.html
@@ -1,4 +1,3 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 <div class="col-video">
   <a class="col-video-link" href="{{ .Get "link_href" }}" target="_self"></a>
     <div class="col-video-title">{{ printf "%s" .Inner | markdownify }}</div>

--- a/layouts/shortcodes/tile_img3.html
+++ b/layouts/shortcodes/tile_img3.html
@@ -1,4 +1,3 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 {{- $tmptile_title_pref := "<div class=\"tmp-tile-title\">" }}
 {{- $tmptile_title := printf "%s(.|\n)*?</div>" $tmptile_title_pref}}
 {{- $div_tile_title := findRE $tmptile_title .Inner }}

--- a/layouts/shortcodes/warning.html
+++ b/layouts/shortcodes/warning.html
@@ -1,4 +1,3 @@
-{{- $_hugo_config := `{ "version": 1 }` -}}
 <aside class="admonition warning">
   <div class="admonition-alt">
 {{- if and (ne .Site.Params.product "Garoon") (ne .Site.Params.product "Mailwise") (ne .Site.Params.product "Office") }}


### PR DESCRIPTION
TcTodo-245

## 想定している進め方

1. このプルリクをレビューしてもらう
1. TC/kintone writerに作業内容と日程を告知する
1. 9月定期メンテ明け（=記事の残プルリクが少なくなっていそうなタイミング）に、このプルリクをマージする
    - [記事によっては表示が崩れる可能性がある。](https://github.dev.cybozu.co.jp/gist/tomonori-aota/ed145e894f928c0276a05208cc8a1b1a#%E4%BF%AE%E6%AD%A3%E5%BE%8C%E3%81%AEhugo-template----)
1. 各製品、なるべく早く{{< >}}に書き換えてもらう
    - 1ヶ月後ぐらいに締切を設定する
1. 記事翻訳をしている製品は、Memsource取り込みを行う際の正規表現を修正する
1. anchorstepとstepindexおよびtileXを使っている製品は、当該記事を修正する

## 動作検証に使用した記事

### 8/16時点のmaster（{{% %}}を使っている）

https://github.com/CybozuDocs/admin/tree/master_0816_per

### {{< >}}に書き換えたブランチ

https://github.com/CybozuDocs/admin/tree/master_0816_lt

## このプルリクで修正したショートコードと{{< >}}に書き換えたブランチを用いた検証結果

記事の表示上、大きな問題はなさそう。

https://github.dev.cybozu.co.jp/gist/tomonori-aota/ed145e894f928c0276a05208cc8a1b1a#%E4%BF%AE%E6%AD%A3%E5%BE%8C%E3%81%AEhugo-template-----1

