### PR TITLE
Improve header css for us

### DIFF
--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -302,8 +302,8 @@ h3.h3-contents:after {
   left: 0;
   top: 76px;
   bottom: 0;
-	border-left: 4px solid #e94f90;
-  border-image: linear-gradient(to top, #287bf4 0%, #e94f90 100%);
+	border-left: 4px solid #A42F29;
+  border-image: linear-gradient(to top, #4A4B4C 0%, #EF3F24 100%);
   border-image-slice: 1;
 }
 

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -307,7 +307,7 @@ h3.h3-contents:after {
   border-image-slice: 1;
 }
 
-.article h4 {
+.contents-wrap h4 {
   font-size: 1.3rem;
 }
 
@@ -331,7 +331,7 @@ h5 + .id-link-button {
   margin-top: 1.4rem;
 }
 
-.article ol {
+.contents-wrap ol {
   padding-left: 0;
 }
 
@@ -365,7 +365,7 @@ h5 + .id-link-button {
 	padding-left: 16px;
 }
 
-.article code, .article pre {
+.contents-wrap code, .contents-wrap pre {
   white-space: inherit;
 }
 

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -271,14 +271,14 @@ h2, h3, h4, h5 {
   font-size: 2.2rem;
 }
 
-.article h2 {
+.contents-wrap h2 {
   margin-top: 2rem;
   padding-top: 2rem;
   font-size: 1.6rem;
   position: relative;
 }
 
-.article h2:after {
+.contents-wrap h2:after {
   content: "";
   border-top: 1px solid #ddd;
   position: absolute;

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -266,7 +266,7 @@ h2, h3, h4, h5 {
   padding: 5px 16px 5px 6px;
 }
 
-.article h1 {
+.contents-wrap h1 {
   padding-top: 3rem;
   font-size: 2.2rem;
 }

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -470,7 +470,6 @@ h5 + .id-link-button {
     }
 
     .contents-wrap {
-      border-left: 1px solid #e6e6e6;
       width: auto;
       flex: auto;
     }

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -9,7 +9,7 @@
   font-style: normal;
 }
 
-/* Header */
+/* Header ***************************************************************/
 .header::before {
   content: none;
 }
@@ -31,7 +31,7 @@
   background-color: #e6e6e6;
 }
 
-/* Eye-catching of the top page */
+/* Eye-catching of the top page *****************************************/
 .main {
   top: -100px;
 }
@@ -204,7 +204,8 @@
     margin-bottom: 7px;
     padding-top: 0px;
 }
-/* Tiles of the top page */
+
+/* Tiles of the top page **********************************************/
 .col-flex {
     margin-top: 10px;
 }
@@ -217,6 +218,97 @@
 
 .fixed-tree {
     top: 98px;
+}
+
+/* 見出し部分の設定 *******************************************************/
+h2, h3, h4, h5 {
+	font-weight: 700
+}
+.header-wrap {
+  padding: 5px 16px 5px 6px
+}
+.article h1 {
+  padding-top: 3rem;
+  font-size: 2.2rem
+}
+.article h2 {
+  margin-top: 2rem;
+  padding-top: 2rem;
+  font-size: 1.6rem;
+  position: relative
+}
+.article h2:after {
+  content: "";
+  border-top: 1px solid #ddd;
+  position: absolute;
+  width: calc(100vw - 32px);
+	top: 0;
+  left: 0
+}
+h3.h3-contents {
+	margin-top: -36px;
+  padding-top: 76px;
+	margin-bottom: 1.5rem;
+	padding-left: .8rem;
+	font-size: 1.4rem;
+	position: relative
+}
+h3.h3-contents:after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 76px;
+  bottom: 0;
+	border-left: 4px solid #e94f90;
+  border-image: linear-gradient(to top, #287bf4 0%, #e94f90 100%);
+  border-image-slice: 1
+}
+.article h4 {
+  font-size: 1.3rem
+}
+h1 + .id-link-button {
+  margin-top: 3.5rem
+}
+h2 + .id-link-button {
+  margin-top: 4.2rem
+}
+h3 + .id-link-button {
+  margin-top: 2.5rem
+}
+h4 + .id-link-button {
+  margin-top: 1.8rem
+}
+h5 + .id-link-button {
+  margin-top: 1.4rem
+}
+.article ol {
+  padding-left: 0
+}
+.sidebar-wrap {
+  background-color: #fff
+}
+#tree-main a {
+	margin-top: 0;
+  margin-bottom: 0
+}
+#tree-main a[aria-expanded="true"] {
+  font-weight: 700
+}
+.jstree-ocl {
+  padding: 0 5px 0 0
+}
+#rightside-bar {
+  margin-top: 6rem
+}
+#tree-main ul {
+  padding-inline-start: 0
+}
+.footer-wrap {
+  padding-right: 16px;
+	padding-left: 16px
+}
+.article code, .article pre {
+  white-space: inherit
 }
 
 /* 古いiPhone向けの設定 ************************************************/
@@ -288,5 +380,3 @@
       margin-top: 100px;
     }
 }
-
-

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -3,6 +3,7 @@
   font-weight: 400;
   font-style: normal;
 }
+
 .font-en .article table th, .font-en .article .admonition .admonition-alt, .font-en .article h1,.font-en .article h2, .font-en .article h5, .font-en .article h6, .font-en .article ol>li:before, .font-en .article caption, .font-en #mainmenu a.expand, .font-en #mainmenu li a.current, .font-en .welcome_message {
   font-family: proxima-nova, sans-serif;
   font-weight: 700;
@@ -13,19 +14,24 @@
 .header::before {
   content: none;
 }
+
 .logo-wrap {
   padding-top: 10px;
 }
+
 .logo-img {
   width: 160px;
   height: 34px;
 }
+
 .logo-product {
   display: none;
 }
+
 .logo-title {
   display: none;
 }
+
 .footer::before {
   background-image: none;
   background-color: #e6e6e6;
@@ -35,9 +41,11 @@
 .main {
   top: -100px;
 }
+
 .page-pad-search {
   height: 56px;
 }
+
 .welcome_message {
   display: block;
   text-align: center;
@@ -46,6 +54,7 @@
   font-size: 2rem;
   margin-bottom: 10px;
 }
+
 .hero {
   display: block;
   background-size: 300px;
@@ -55,6 +64,7 @@
   margin-left: auto;
   margin-right: auto;
 }
+
 .eye-catching {
   background-color: #ee3e23;
 }
@@ -64,6 +74,7 @@
   z-index: 900;
   box-shadow: none;
 }
+
 .mega-nav {
   font-size: 1em;
   background: #4a4B4c;
@@ -73,41 +84,50 @@
 .mega-tab-short {
   color: #fff;
 }
+
 .mega-tab-short-wrap {
   display: flex;
   align-items: center;
 }
+
 #mega-tab-switch {
   margin: .2em;
   padding: .2em;
   cursor: pointer;
 }
+
 #mega-tab-switch:focus-visible {
   outline: solid 2px #fff;
   border-radius: 3px;
 }
+
 .mega-tab-switch-icon {
   margin-left: .2em;
   margin-right: .2em;
   color: #fff;
   font-size: 1.5rem;
 }
+
 .mega-tab-bar {
   display: none;
   width: 100%;
   z-index: 99;
 }
+
 .mega-tab-bar ul {
   width: 100%;
 }
+
 .mega-tab-bar li {
   display: list-item;
   padding: 0;
   margin: 0;
 }
+
 .mega-tab-wrap {
   display: block;
 }
+
 .mega-tab {
   font-size: .875rem;
   line-height: 1.2;
@@ -116,34 +136,42 @@
   background: none;
   padding: .7em;
 }
+
 .mega-tab[aria-expanded="true"] {
   background-color: #a42e25;
 }
+
 .mega-tab:hover {
   background: #a42f29;
 }
+
 .mega-tab.current {
   font-weight: inherit;
   background: #5e1b15;
 }
+
 .mega-tab.current:hover {
   background: #a42f29;
 }
+
 .mega-tab:focus-visible {
   outline: solid 2px #fff;
   border-radius: 3px;
   margin: 1px 0 1px 0;
 }
+
 .mega-tab i {
   display: inline-block;
   padding-top: 0;
   color: #fff;
 }
+
 .mega-tab-text {
   font-size: 1.2em;
   white-space: nowrap;
   margin-left: 1em;
 }
+
 .mega-panel {
   width: auto;
   background: #a42e25;
@@ -154,9 +182,11 @@
   font-size: .8em;
   margin-top: 3px;
 }
+
 .mega-panelplace {
   background: #a42e25;
 }
+
 .mega-list {
   column-count: 1;
   text-align: left;
@@ -166,22 +196,27 @@
   margin-left: 2em;
   margin-bottom: 8px;
 }
+
 .mega-list-line {
   box-sizing: border-box;
   font-size: .8em;
   margin-bottom: 0;
   padding: .2em 1em .2em 1em;
 }
+
 .mega-list-line.current {
   background: #5e1b15;
 }
+
 .mega-list-line:hover {
   background-color: #5e1a13;
   cursor: pointer;
 }
+
 .mega-list-item {
   padding: 0;
 }
+
 .mega-list-item:focus {
   outline: solid 2px #fff;
   border-radius: 3px;
@@ -209,9 +244,11 @@
 .col-flex {
     margin-top: 10px;
 }
+
 .col-tile {
   border-radius: 10px;
 }
+
 .col-tile i {
   color: #EE3E23 !important;
 }
@@ -224,19 +261,23 @@
 h2, h3, h4, h5 {
 	font-weight: 700;
 }
+
 .header-wrap {
   padding: 5px 16px 5px 6px;
 }
+
 .article h1 {
   padding-top: 3rem;
   font-size: 2.2rem;
 }
+
 .article h2 {
   margin-top: 2rem;
   padding-top: 2rem;
   font-size: 1.6rem;
   position: relative;
 }
+
 .article h2:after {
   content: "";
   border-top: 1px solid #ddd;
@@ -245,6 +286,7 @@ h2, h3, h4, h5 {
 	top: 0;
   left: 0;
 }
+
 h3.h3-contents {
 	margin-top: -36px;
   padding-top: 76px;
@@ -253,6 +295,7 @@ h3.h3-contents {
 	font-size: 1.4rem;
 	position: relative;
 }
+
 h3.h3-contents:after {
   content: "";
   position: absolute;
@@ -263,50 +306,65 @@ h3.h3-contents:after {
   border-image: linear-gradient(to top, #287bf4 0%, #e94f90 100%);
   border-image-slice: 1;
 }
+
 .article h4 {
   font-size: 1.3rem;
 }
+
 h1 + .id-link-button {
   margin-top: 3.5rem;
 }
+
 h2 + .id-link-button {
   margin-top: 4.2rem;
 }
+
 h3 + .id-link-button {
   margin-top: 2.5rem;
 }
+
 h4 + .id-link-button {
   margin-top: 1.8rem;
 }
+
 h5 + .id-link-button {
   margin-top: 1.4rem;
 }
+
 .article ol {
   padding-left: 0;
 }
+
 .sidebar-wrap {
   background-color: #fff;
 }
+
 #tree-main a {
 	margin-top: 0;
   margin-bottom: 0;
 }
+
 #tree-main a[aria-expanded="true"] {
   font-weight: 700;
 }
+
 .jstree-ocl {
   padding: 0 5px 0 0;
 }
+
 #rightside-bar {
   margin-top: 6rem;
 }
+
 #tree-main ul {
   padding-inline-start: 0;
 }
+
 .footer-wrap {
   padding-right: 16px;
 	padding-left: 16px;
 }
+
 .article code, .article pre {
   white-space: inherit;
 }
@@ -323,82 +381,104 @@ h5 + .id-link-button {
     .logo-img {
         margin-top: -4px;
     }
+
     .hero {
       background-size: 300px;
       height: 250px;
       max-width: 1300px;
     }
+
     .mnav-pad {
         height:41px;
     }
+
     .mega-nav-bar {
         position: fixed;
         top: 56px;
         box-shadow: 1px 1px 2px #726464;
     }
+
     .mega-tab, .mega-tab[aria-expanded="true"]:hover {
        border-bottom: 1px solid transparent;
     }
+
     .mega-tab:hover {
        border-bottom: 1px solid #fff;
     }
+
     .mega-tab:focus-visible {
        margin: -2px;
     }
+
     .mega-tab-short {
         display: none;
     }
+
     .mega-tab-bar {
         position: relative;
         top: 0;
         display: block;
     }
+
     .mega-tab-bar ul {
         width: auto;
     }
+
     .mega-tab-bar li {
         display: table-cell;
     }
+
     .mega-list {
         border-left: none;
         margin-left: 0;
         margin-bottom: 8px;
     }
+
     .mega-list-line {
         padding: .2em 1em .2em 2em;
     }
+
     .mega-panel {
         font-size: 1em;
         box-shadow: 1px 2px 4px #b91616;
         margin-top: 0;
     }
+
     .main {
       top: -182px;
     }
+
     .page {
       padding-right: 16px;
     }
+
     .tree-wrap {
       padding-left: 6px;
       flex: 0 0 292px;
     }
+
     .article h2:after {
       width: calc(100vw - 342px);
     }
+
     #tree-nav {
       border-right: none;
     }
+
     .contents-wrap {
       border-left: 1px solid #e6e6e6;
       width: auto;
       flex: auto;
     }
+
     #tree-main ul {
       padding-inline-start: 10px;
     }
+
     .jstree-container-ul {
       padding-top: 18px;
     }
+
     /* Tiles of the top page */
     .col-flex {
       margin-top: 100px;
@@ -412,6 +492,7 @@ h5 + .id-link-button {
     flex: 0 0 232px;
     padding-left: 32px;
   }
+  
   .article h2:after {
     width: calc(100vw - 542px);
   }

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -375,6 +375,30 @@ h5 + .id-link-button {
     .main {
       top: -182px;
     }
+    .page {
+      padding-right: 16px
+    }
+    .tree-wrap {
+      padding-left: 6px;
+      flex: 0 0 292px
+    }
+    .article h2:after {
+      width: calc(100vw - 342px)
+    }
+    #tree-nav {
+      border-right: none
+    }
+    .contents-wrap {
+      border-left: 1px solid #e6e6e6;
+      width: auto;
+      flex: auto
+    }
+    #tree-main ul {
+      padding-inline-start: 10px;
+    }
+    .jstree-container-ul {
+      padding-top: 18px
+    }
     /* Tiles of the top page */
     .col-flex {
       margin-top: 100px;

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -222,20 +222,20 @@
 
 /* 見出し部分の設定 *******************************************************/
 h2, h3, h4, h5 {
-	font-weight: 700
+	font-weight: 700;
 }
 .header-wrap {
-  padding: 5px 16px 5px 6px
+  padding: 5px 16px 5px 6px;
 }
 .article h1 {
   padding-top: 3rem;
-  font-size: 2.2rem
+  font-size: 2.2rem;
 }
 .article h2 {
   margin-top: 2rem;
   padding-top: 2rem;
   font-size: 1.6rem;
-  position: relative
+  position: relative;
 }
 .article h2:after {
   content: "";
@@ -243,7 +243,7 @@ h2, h3, h4, h5 {
   position: absolute;
   width: calc(100vw - 32px);
 	top: 0;
-  left: 0
+  left: 0;
 }
 h3.h3-contents {
 	margin-top: -36px;
@@ -251,7 +251,7 @@ h3.h3-contents {
 	margin-bottom: 1.5rem;
 	padding-left: .8rem;
 	font-size: 1.4rem;
-	position: relative
+	position: relative;
 }
 h3.h3-contents:after {
   content: "";
@@ -261,54 +261,54 @@ h3.h3-contents:after {
   bottom: 0;
 	border-left: 4px solid #e94f90;
   border-image: linear-gradient(to top, #287bf4 0%, #e94f90 100%);
-  border-image-slice: 1
+  border-image-slice: 1;
 }
 .article h4 {
-  font-size: 1.3rem
+  font-size: 1.3rem;
 }
 h1 + .id-link-button {
-  margin-top: 3.5rem
+  margin-top: 3.5rem;
 }
 h2 + .id-link-button {
-  margin-top: 4.2rem
+  margin-top: 4.2rem;
 }
 h3 + .id-link-button {
-  margin-top: 2.5rem
+  margin-top: 2.5rem;
 }
 h4 + .id-link-button {
-  margin-top: 1.8rem
+  margin-top: 1.8rem;
 }
 h5 + .id-link-button {
-  margin-top: 1.4rem
+  margin-top: 1.4rem;
 }
 .article ol {
-  padding-left: 0
+  padding-left: 0;
 }
 .sidebar-wrap {
-  background-color: #fff
+  background-color: #fff;
 }
 #tree-main a {
 	margin-top: 0;
-  margin-bottom: 0
+  margin-bottom: 0;
 }
 #tree-main a[aria-expanded="true"] {
-  font-weight: 700
+  font-weight: 700;
 }
 .jstree-ocl {
-  padding: 0 5px 0 0
+  padding: 0 5px 0 0;
 }
 #rightside-bar {
-  margin-top: 6rem
+  margin-top: 6rem;
 }
 #tree-main ul {
-  padding-inline-start: 0
+  padding-inline-start: 0;
 }
 .footer-wrap {
   padding-right: 16px;
-	padding-left: 16px
+	padding-left: 16px;
 }
 .article code, .article pre {
-  white-space: inherit
+  white-space: inherit;
 }
 
 /* 古いiPhone向けの設定 ************************************************/
@@ -376,28 +376,28 @@ h5 + .id-link-button {
       top: -182px;
     }
     .page {
-      padding-right: 16px
+      padding-right: 16px;
     }
     .tree-wrap {
       padding-left: 6px;
-      flex: 0 0 292px
+      flex: 0 0 292px;
     }
     .article h2:after {
-      width: calc(100vw - 342px)
+      width: calc(100vw - 342px);
     }
     #tree-nav {
-      border-right: none
+      border-right: none;
     }
     .contents-wrap {
       border-left: 1px solid #e6e6e6;
       width: auto;
-      flex: auto
+      flex: auto;
     }
     #tree-main ul {
       padding-inline-start: 10px;
     }
     .jstree-container-ul {
-      padding-top: 18px
+      padding-top: 18px;
     }
     /* Tiles of the top page */
     .col-flex {
@@ -410,9 +410,9 @@ h5 + .id-link-button {
   .sidebar-wrap {
     float: none;
     flex: 0 0 232px;
-    padding-left: 32px
+    padding-left: 32px;
   }
   .article h2:after {
-    width: calc(100vw - 542px)
+    width: calc(100vw - 542px);
   }
 }

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -404,3 +404,15 @@ h5 + .id-link-button {
       margin-top: 100px;
     }
 }
+
+/* 1059px以上の設定 *****************************************************/
+@media (min-width:1059px) {
+  .sidebar-wrap {
+    float: none;
+    flex: 0 0 232px;
+    padding-left: 32px
+  }
+  .article h2:after {
+    width: calc(100vw - 542px)
+  }
+}

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -311,6 +311,10 @@ h3.h3-contents:after {
   font-size: 1.3rem;
 }
 
+.contents-wrap h5 {
+  font-weight: 700;
+}
+
 h1 + .id-link-button {
   margin-top: 3.5rem;
 }


### PR DESCRIPTION
helpmanage-1126

ぴよさんにレビューしてもらい、疋田さんにもらったCSSに↓を上書きしています。

*  h3のアクセントカラーをUSヘルプになじむ配色に
* 「.article」→「.contents-wrap」に変更
* h5のWeightを上書き
* 検索画面の左側にでていた縦線を削除