### PR TITLE
右ナビの表示崩れの対処

### DIFF
--- a/static/stylesheets/custom_general.css
+++ b/static/stylesheets/custom_general.css
@@ -194,10 +194,6 @@ h5 + .id-link-button {
   padding: 0 5px 0 0;
 }
 
-#rightside-bar {
-  margin-top: 6rem;
-}
-
 #tree-main ul {
   padding-inline-start: 0;
 }

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -356,10 +356,6 @@ h5 + .id-link-button {
   padding: 0 5px 0 0;
 }
 
-#rightside-bar {
-  margin-top: 6rem;
-}
-
 #tree-main ul {
   padding-inline-start: 0;
 }


### PR DESCRIPTION
右ナビに出す見出し数が多い場合に、右ナビがフッターにはみ出してしまっていた。
それを解消するための修正。

暫定的に↓をカットする対処を行った。

> #rightside-bar {
  margin-top: 6rem;
}