### PR TITLE
ページ右端が切れてしまう

### DIFF
--- a/static/stylesheets/custom_general.css
+++ b/static/stylesheets/custom_general.css
@@ -245,11 +245,6 @@ h5 + .id-link-button {
     border-right: none;
   }
 
-  .contents-wrap {
-    width: auto;
-    flex: auto;
-  }
-
   #tree-main ul {
     padding-inline-start: 10px;
   }

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -461,10 +461,6 @@ h5 + .id-link-button {
       border-right: none;
     }
 
-    .contents-wrap {
-      flex: auto;
-    }
-
     #tree-main ul {
       padding-inline-start: 10px;
     }

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -462,7 +462,6 @@ h5 + .id-link-button {
     }
 
     .contents-wrap {
-      width: auto;
       flex: auto;
     }
 


### PR DESCRIPTION
US向けヘルプで発生している↓への対処
* 横に長いコードブロックを含む記事で、ページ右端が切れてしまう