### PR TITLE
change the title name for US region

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,9 +14,6 @@
         <article class="article home-article" >
             <div class="wrapper">
                 {{- $toptitle := (i18n "Welcome" .) }}
-                {{- if eq $.Site.Params.TargetRegion "US" }}
-                    {{ $toptitle = printf "%s %s" .Site.Params.kintone (i18n "Help_site") }}
-                {{- end }}
                 <div class="welcome_message">{{$toptitle}}</div>
                 <div class="search-wrap">
                     <form id="headerSearchBox_form" action="{{ "" | relURL }}{{.Lang}}/search_result.html"　onsubmit='if(document.getElementById("headerSearchBox_input").value==""){return false;}' role="search">

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -17,8 +17,6 @@
         <a href="{{- .p1.Permalink -}}">
             {{- if and (.p1.IsHome) (or (eq .p1.Site.Params.product "Garoon") (eq .p1.Site.Params.product "Mailwise") (eq .p1.Site.Params.product "Office")) -}}
                 {{- i18n "Top_page" -}}
-            {{- else if and (.p1.IsHome) (eq .p1.Site.Params.TargetRegion "US") -}}
-                {{ .p1.Site.Params.kintone }}&nbsp;{{- i18n "Help_site" -}}
             {{- else }}
                 {{- partial "title" .p1 -}}
             {{- end -}}


### PR DESCRIPTION
https://bozuman.cybozu.com/k/#/space/22/thread/42063/3896071/7774546

[ドメイントップページのタイトルを変える件](https://bozuman.cybozu.com/k/#/space/22/thread/42063/3896071/7774546)の反映
- USリージョンで表示されるウェルカムメッセージとパンくずリストを変えるにはテンプレートの更新が必要なので、本PRを発行。USリージョンだけ表示を変える分岐が不要になるので、削除する。
- i18nの[Help_site]は残す。[フッター](https://github.com/CybozuDocs/hugo-template/blob/8d15700fd6184ea99de28d3841f252ef498fa98b/layouts/partials/footer.html#L50)で使っているため。