### PR TITLE
Adjusted kintone CSS for Codeblocks

### DIFF
--- a/static/stylesheets/custom_kin.css
+++ b/static/stylesheets/custom_kin.css
@@ -1,9 +1,8 @@
 /* コードブロックで利用する設定 ********************************************/
-.highlight pre {
+.article pre {
     border-radius: 4px;
 }
 .codeblock-copy-button {
-    right: 4px;
     top: 10px;
 }
 .codeblock-wrapper + p {

--- a/static/stylesheets/custom_kin.css
+++ b/static/stylesheets/custom_kin.css
@@ -1,8 +1,9 @@
 /* コードブロックで利用する設定 ********************************************/
-.codeblock-wrapper {
+.highlight pre {
     border-radius: 4px;
 }
 .codeblock-copy-button {
+    right: 4px;
     top: 10px;
 }
 .codeblock-wrapper + p {

--- a/static/stylesheets/custom_kin.css
+++ b/static/stylesheets/custom_kin.css
@@ -1,4 +1,10 @@
 /* コードブロックで利用する設定 ********************************************/
+.codeblock-wrapper {
+    border-radius: 4px;
+}
+.codeblock-copy-button {
+    top: 10px;
+}
 .codeblock-wrapper + p {
     margin-top: 0.9em;
 }

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -233,6 +233,9 @@
 .highlight pre {
   border-radius: 4px;
 }
+.codeblock-copy-button {
+  top: 10px;
+}
 .codeblock-wrapper + p {
   margin-top: 0.9em;
 }

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -230,7 +230,7 @@
     }
 
 /* コードブロックで利用する設定 ********************************************/
-.highlight pre {
+.article pre {
   border-radius: 4px;
 }
 .codeblock-copy-button {

--- a/static/stylesheets/theme_us.css
+++ b/static/stylesheets/theme_us.css
@@ -230,6 +230,9 @@
     }
 
 /* コードブロックで利用する設定 ********************************************/
+.highlight pre {
+  border-radius: 4px;
+}
 .codeblock-wrapper + p {
   margin-top: 0.9em;
 }


### PR DESCRIPTION
コードブロック周りのスタイルについて、QAチェックでフィードバックのあった部分を改善する。
- 1行で表示されたときに、コピーボタンが中央よりに表示されるようにする（いったん日本語のみ）
- 角丸にする