### PR TITLE
img max-widthを600pxに変更/kintoneのコピーボタンの位置調整

### DIFF
--- a/static/stylesheets/application.css
+++ b/static/stylesheets/application.css
@@ -1064,7 +1064,7 @@ h6 + .id-link-button {
     overflow: auto;
 }
 .article img {
-    max-width: 100%
+    max-width: 600px;
 }
 .article img.screenshot {
     margin: 21px 0;

--- a/static/stylesheets/custom_kin.css
+++ b/static/stylesheets/custom_kin.css
@@ -4,6 +4,7 @@
 }
 .codeblock-copy-button {
     top: 10px;
+    right: 10px;
 }
 .codeblock-wrapper + p {
     margin-top: 0.9em;


### PR DESCRIPTION
- スクリーンショットの表示幅のMax値を、Garoonと同じ600pxに変更（.article img）
- kintoneのコピーボタンの位置を右から10px取るように変更
