### PR TITLE
スクリーンショットのmax-widthを調整する

### DIFF
--- a/static/stylesheets/application.css
+++ b/static/stylesheets/application.css
@@ -1064,7 +1064,7 @@ h6 + .id-link-button {
     overflow: auto;
 }
 .article img {
-    max-width: 600px;
+    max-width: 100%;
 }
 .article img.screenshot {
     margin: 21px 0;
@@ -2421,6 +2421,11 @@ i.index-pdf {
     }
     .close-enquete {
         display: block;
+    }
+    /* -------------------------------- article style */
+
+    .article img.screenshot {
+        max-width: 600px;
     }
 }
 


### PR DESCRIPTION
モバイルのことが考慮されていなかったため、CSSを修正する。

- 全体の設定は「100%」にする
- 1059px以上の表示を設定するセクションで、「600px」の設定をする