### PR TITLE
Officeの個人設定サブナビにh2/h3配下が表示されるよう設定

### DIFF
--- a/layouts/partials/treenav.html
+++ b/layouts/partials/treenav.html
@@ -13,7 +13,7 @@
     {{- else if eq $.Site.Params.product "Mailwise" }}
         {{- $lastpage = (slice "/user/basic/" "/user/personal/" "/admin/spec/" "/admin/system/" "/option/migration/" "/intro/first/" "/intro/install/" "/intro/verup/" "/intro/uninstall/") }}
     {{- else if eq $.Site.Params.product "Office" }}
-        {{- $lastpage = (slice "/intro/first/" "/intro/install/" "/intro/uninstall/" "/option/migration/" "/guide/" "/pdf/" "/error/") }}
+        {{- $lastpage = (slice "/intro/first/" "/intro/install/" "/intro/uninstall/" "/option/migration/" "/guide/" "/pdf/" "/error/" "/user/per/") }}
     {{- else if eq $.Site.Params.product "Remote" }}
         {{- $lastpage = (slice "/intro/" "/admin/" "/user/") }}
     {{- end }}


### PR DESCRIPTION
https://jp.cybozu.help/of10/ja/user/per/p08.html 
階層を持たないので子ページがないため、h2見出しとh3見出しが表示されていないので対応。

https://bozuman.cybozu.com/k/#/space/3963/thread/24011/5406854