### PR TITLE
Add preview site

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,12 +7,17 @@
 <div class="mnav-pad"></div>
     {{ partial "meganav" . }}
 {{- end -}}
+{{- if ne $.Site.Params.preview_site true }}
     <div class="eye-catching">
         <div class="hero" style="background-image: url('{{ "images/hero_common.png" | relURL}}');"></div>
     </div>
+{{- end }}
     <main class="main">
         <article class="article home-article" >
             <div class="wrapper">
+              {{- if eq $.Site.Params.preview_site true }}
+                {{ partial "preview_list" . }}
+              {{- else }}
                 {{- $toptitle := (i18n "Welcome" .) }}
                 <div class="welcome_message">{{$toptitle}}</div>
                 <div class="search-wrap">
@@ -34,6 +39,7 @@
               <nav class="col-flex">
                     {{ .Content }}
               </nav>
+              {{- end }}
             </div>
         </article>
     </main>

--- a/layouts/partials/enquete.html
+++ b/layouts/partials/enquete.html
@@ -1,3 +1,4 @@
+{{- if ne $.Site.Params.preview_site true }}
 <aside id="enquete">
     <div class="enquete-panel">
       <div>{{ i18n "Was_it_helpful" }}<button class="close-enquete" id="close-enquete" title='{{ i18n "Close" }}'><i class="far fa-window-close"></i></button></div>
@@ -9,3 +10,4 @@
 </aside>
 {{- $buildnum := (now.Format "2006010203") }}
 <script src="{{ printf "%s?%s" "javascripts/enquete.js" $buildnum | relURL }}"></script>
+{{- end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,3 +1,4 @@
+{{- if ne $.Site.Params.preview_site true }}
 {{- $footerLinks_Ex := "" }}
 {{- if eq $.Site.Params.id_search true }}
     {{- $footerLinks_Ex = "footer-links-ex" }}
@@ -76,4 +77,5 @@
         </div>
     </div>
 </footer>
+{{- end -}}
 {{- end -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -23,7 +23,12 @@
                 {{- end }}
                         <img class="logo-img" src="{{ $.Site.BaseURL }}{{.}}" alt="{{$alt}}" title="{{$alt}}" aria-hidden="{{$hidden}}">
             {{- end -}}
-            {{- $title := printf "%s %s" ($.Scratch.Get "sitename") $.Site.Params.help -}}
+            {{- $title := "" }}
+            {{- if eq $.Site.Params.preview_site true }}
+                {{- $title = $.Site.Params.product_name }}
+            {{- else }}
+                {{- $title = printf "%s %s" ($.Scratch.Get "sitename") $.Site.Params.help -}}
+            {{- end }}
                         <span class="logo-title">{{$title}}</span>
                     </button>
                 </h1>
@@ -38,6 +43,8 @@
         {{- else if and (eq $.Site.Params.TargetRegion "US") .IsHome }}
             {{- $disp_sbox = false }}
         {{- else if eq .Params.type "gr6/home" }}
+            {{- $disp_sbox = false }}
+        {{- else if eq $.Site.Params.preview_site true }}
             {{- $disp_sbox = false }}
         {{- end }}
 

--- a/layouts/partials/preview_list.html
+++ b/layouts/partials/preview_list.html
@@ -2,7 +2,9 @@
     <div class="preview_list_container">
 {{- range .Sections.ByWeight}}
       <div class="preview_list_item" role="presentation">
-        <a href="{{.RelPermalink}}">{{- partial "title" . -}}</a>
+        <div class="preview_list_title">
+          <a href="{{.RelPermalink}}">{{- partial "title" . -}}</a>
+        </div>
         <ul>
         {{- range .Pages.ByWeight}}
         <li>

--- a/layouts/partials/preview_list.html
+++ b/layouts/partials/preview_list.html
@@ -1,0 +1,19 @@
+<nav>
+    <div class="preview_list_container">
+{{- range .Sections.ByWeight}}
+      <div class="preview_list_item" role="presentation">
+        <a href="{{.RelPermalink}}">{{- partial "title" . -}}</a>
+        <ul>
+        {{- range .Pages.ByWeight}}
+        <li>
+          <a href="{{.RelPermalink}}">{{- partial "title" . -}}</a>
+        </li>
+        {{- end }}
+        </ul>
+      </div>
+{{- end }}
+    </div>
+</nav>
+
+
+

--- a/layouts/partials/treenav.html
+++ b/layouts/partials/treenav.html
@@ -77,8 +77,15 @@
   <nav id="tree-main" tabindex="0">
     <ul>
 {{- $target := .}}
+
 {{- range $entries.ByWeight}}
-    {{- template "mainmenu" (dict "curnode" . "target" $target "needtoc" $needtoc "tocregex" $tocregex )}}
+    {{- $disp := true }}
+    {{- if and (eq $.Site.Params.preview_site true) (ne $target.FirstSection .) }}
+        {{- $disp = false }}
+    {{- end }}
+    {{ if eq $disp true }} 
+        {{- template "mainmenu" (dict "curnode" . "target" $target "needtoc" $needtoc "tocregex" $tocregex )}}
+    {{- end }}
 {{- end}}
     </ul>
   </nav>

--- a/static/stylesheets/custom_preview_site.css
+++ b/static/stylesheets/custom_preview_site.css
@@ -28,6 +28,11 @@
     background-color: #fbf6c1;
 }
 
+.preview_list_title {
+    font-size: 1.2em;
+    font-weight: bold;
+}
+
 .preview_list_item li {
     list-style-type: none;
 }

--- a/static/stylesheets/custom_preview_site.css
+++ b/static/stylesheets/custom_preview_site.css
@@ -1,0 +1,64 @@
+.header {
+    background-color: #333;
+}
+
+.header::before {
+    background-image: none;
+}
+
+.logo-title {
+    color: #fdb50f;
+}
+
+.main {
+    top: 0;
+}
+
+.preview_list_container {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 10px;
+}
+
+.preview_list_item {
+    border: 1px solid #999;
+    border-radius: 10%;
+    padding: 20px;
+    margin: 10px;
+    background-color: #fbf6c1;
+}
+
+.preview_list_item li {
+    list-style-type: none;
+}
+.preview_list_item a {
+    text-decoration: none;
+    white-space: nowrap;
+    color: #000;
+}
+
+@media print {
+    .book-title {
+        width: 600px;
+    }
+}
+
+/* definition listの設定 -------------------------------------- */
+
+.article dl {
+    margin: 5px;
+  }
+  
+  .article dt {
+    margin-bottom: 7px;
+    font-weight: bold;
+  }
+  
+  .article dl > dt:nth-child(n + 2) {
+    margin-top: 14px;
+  }
+  
+  .article dd {
+    margin-bottom: 7px;
+    padding-left: 20px;
+  }


### PR DESCRIPTION
修正概要
　ヘッダーのデザインを変更
　　製品本体のヘルプと別物であることがわかるように

　専用のhomeページを用意
　　第2階層までを表示するタイルを並べる

　不要パーツの非表示
　　ヘッダーの検索窓
　　フッター
　　アンケートボタン

　ツリーナビゲーションはホームページで選択したものだけを表示する

設定
　hugo.tomlのparamsに以下の設定を追加する。
　　preview_site = true

　ページタイトルはproduct_nameを表示する形にしているので、
　EPプラグインでは以下のようにすると製品本体のヘルプと区別できる。

　[languages.en.params]
      product_name = "kintone EP プラグイン"

　