### PR TITLE
メールワイズの目的別ガイドのサブナビ表示変更

### DIFF
--- a/layouts/partials/treenav.html
+++ b/layouts/partials/treenav.html
@@ -11,7 +11,7 @@
     {{- if eq $.Site.Params.product "Garoon" }}
         {{- $lastpage = (slice "/purpose/" "/user/basic/" "/mobile/" "/user/mobile/" "/user/personal/" "/admin/spec/" "/admin/system/" "/glossary/" "/intro/" "/option/fullsearch/" "/error/") }}
     {{- else if eq $.Site.Params.product "Mailwise" }}
-        {{- $lastpage = (slice "/user/basic/" "/user/personal/" "/admin/spec/" "/admin/system/" "/option/migration/" "/intro/first/" "/intro/install/" "/intro/verup/" "/intro/uninstall/") }}
+        {{- $lastpage = (slice "/user/basic/" "/user/personal/" "/admin/spec/" "/admin/system/" "/option/migration/" "/intro/first/" "/intro/install/" "/intro/verup/" "/intro/uninstall/" "/purpose/") }}
     {{- else if eq $.Site.Params.product "Office" }}
         {{- $lastpage = (slice "/intro/first/" "/intro/install/" "/intro/uninstall/" "/option/migration/" "/guide/" "/pdf/" "/error/" "/user/per/") }}
     {{- else if eq $.Site.Params.product "Remote" }}


### PR DESCRIPTION
メールワイズに目的別ガイドが追加されたため、サブナビの表示方法をGaroonと同じにする対応。
https://bozuman.cybozu.com/k/55371/show#record=255&comment=2