### PR TITLE
TcTodo-422: XML 形式のサイトマップ中の URL を修正

### DIFF
--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -4,19 +4,19 @@
   {{ range .Data.Pages }}
     {{- if .Permalink -}}
   <url>
-    <loc>https://{{.Site.Params.domain}}{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
     <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
     <xhtml:link
                 rel="alternate"
                 hreflang="{{ .Language.Lang }}"
-                href="https://{{.Site.Params.domain}}{{ .Permalink }}"
+                href="{{ .Permalink }}"
                 />{{ end }}
     <xhtml:link
                 rel="alternate"
                 hreflang="{{ .Language.Lang }}"
-                href="https://{{.Site.Params.domain}}{{ .Permalink }}"
+                href="{{ .Permalink }}"
                 />{{ end }}
   </url>
     {{- end -}}


### PR DESCRIPTION
## 動機

https://bozuman.cybozu.com/k/38375/show#record=422

## やったこと

全製品のヘルプサイトで生じている不具合ということから、全製品で共通して利用しているテンプレートの URL を修正しました。

この変更を加えたサイトマップを以下に示します:

Garoon の場合
<img width="819" alt="スクリーンショット 2025-03-07 18 45 06" src="https://github.com/user-attachments/assets/39d016cf-a6dd-464b-8e67-fabfaf380cff" />

kintone の場合
<img width="854" alt="スクリーンショット 2025-03-07 18 48 17" src="https://github.com/user-attachments/assets/fef3a681-cab3-4a33-8813-ad9906ca0bf6" />