### PR TITLE
TcTodo-448: トップページのドロップダウンリストにおいて、表示すべきでないページが表示されている不具合の修正

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -132,7 +132,9 @@
                 <button type="button" id="top-page-card-{{$i}}" class="top-page-card top-page-card-parent" aria-controls="top-page-panel-{{$i}}" aria-haspopup="true" aria-expanded="false">{{- partial "title" . -}}</button>
                   <ul id="top-page-panel-{{$i}}" class="top-page-panel" aria-labelledby="top-page-card-{{$i}}" tabindex="-1" role="menu">
                   {{- range $idx, $page := slice . | append $pages }}
+                    {{- if or (eq .Params.disabled nil) (not (in .Params.disabled .Site.Params.TargetRegion)) }}
                     <li role="none"><a href={{.RelPermalink}} role="menuitem" itemnum="{{$idx}}" tabindex="-1"><span class="top-page-item">{{- partial "title" $page -}}</span></a></li>
+                    {{- end }}
                   {{- end }}
                   </ul>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -131,10 +131,17 @@
                 {{- if gt ($pages | len) 0 }}
                 <button type="button" id="top-page-card-{{$i}}" class="top-page-card top-page-card-parent" aria-controls="top-page-panel-{{$i}}" aria-haspopup="true" aria-expanded="false">{{- partial "title" . -}}</button>
                   <ul id="top-page-panel-{{$i}}" class="top-page-panel" aria-labelledby="top-page-card-{{$i}}" tabindex="-1" role="menu">
-                  {{- range $idx, $page := slice . | append $pages }}
+
+                  {{/* `itemnum` の値を連番にするため、予め条件に該当するページのスライスを作り直している */}}
+                  {{- $displayed_pages := slice}}
+                  {{- range $page := slice . | append $pages }}
                     {{- if or (eq .Params.disabled nil) (not (in .Params.disabled .Site.Params.TargetRegion)) }}
-                    <li role="none"><a href={{.RelPermalink}} role="menuitem" itemnum="{{$idx}}" tabindex="-1"><span class="top-page-item">{{- partial "title" $page -}}</span></a></li>
+                      {{- $displayed_pages = $displayed_pages | append $page }}
                     {{- end }}
+                  {{- end }}
+
+                  {{- range $idx, $page := $displayed_pages }}
+                      <li role="none"><a href={{.RelPermalink}} role="menuitem" itemnum="{{$idx}}" tabindex="-1"><span class="top-page-item">{{- partial "title" $page -}}</span></a></li>
                   {{- end }}
                   </ul>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -131,11 +131,8 @@
                 {{- if gt ($pages | len) 0 }}
                 <button type="button" id="top-page-card-{{$i}}" class="top-page-card top-page-card-parent" aria-controls="top-page-panel-{{$i}}" aria-haspopup="true" aria-expanded="false">{{- partial "title" . -}}</button>
                   <ul id="top-page-panel-{{$i}}" class="top-page-panel" aria-labelledby="top-page-card-{{$i}}" tabindex="-1" role="menu">
-                    <li role="none"><a href={{.RelPermalink}} role="menuitem" itemnum="0" tabindex="-1"><span class="top-page-item">{{- partial "title" . -}}</span></a></li>
-                  {{- range $idx, $page := $pages }}
-                    {{- if ne .Type "redirect_js" }}
-                    <li role="none"><a href={{.RelPermalink}} role="menuitem" itemnum="{{add $idx 1}}" tabindex="-1"><span class="top-page-item">{{- partial "title" $page -}}</span></a></li>
-                    {{- end }}
+                  {{- range $idx, $page := slice . | append $pages }}
+                    <li role="none"><a href={{.RelPermalink}} role="menuitem" itemnum="{{$idx}}" tabindex="-1"><span class="top-page-item">{{- partial "title" $page -}}</span></a></li>
                   {{- end }}
                   </ul>
 


### PR DESCRIPTION
## モチベーション

TcTodo-448 トップページのプルダウンメニューにリージョン別の切り分けを行う
https://bozuman.cybozu.com/k/38375/show#record=448

補足すると、[本タスクの調査](https://bozuman.cybozu.com/k/#/space/22/thread/99783/5651488/11544575)により、今回の修正対象は依頼元で報告されている2つのページだけではなく、全ページであるとわかった。

## やったこと

前提として、ヘルプサイトの記事の基となるマークダウンファイルでは、Front Matter を利用し、表示すべきリージョンを指定している（[例](https://github.com/CybozuDocs/kintone/blob/6e67bb0613efc96477b181f2f942aa4ab632246a/content/ja/trouble_shooting/disk_storage/_index.md)）。

今回の問題の原因は、その表示すべきリージョンに関わらず、常に全てのページを描画していることだった。そのため、表示すべきかどうかの条件分岐を入れるだけで対処可能だった。

### 意図しない変更が加わってないかの調査

先述した修正を施すことで、表示すべきでないページは表示されなくなってほしいが、そうではないページは表示され続けてほしい。この種の意図しない変更が加わってないか、修正前と修正後のトップページの HTML の差分をとって調査した。この調査により、表示すべきページのみドロップダウンリストに表示されているとわかった。

以降は、実際に取った差分を列挙する。

#### 日本向けヘルプサイトのトップページの差分

```sh
$ diff jp-before.html jp-after.html
460d459
<                     <li role="none"><a href=/k/ja/trouble_shooting/disk_storage.html role="menuitem" itemnum="11" tabindex="-1"><span class="top-page-item">ディスク容量に関する質問</span></a></li>
```

#### US 向けヘルプサイトのトップページの差分

```sh
$ diff us-before.html us-after.html
290,291d289
<                     <li role="none"><a href=/k/ja/start/login_started.html role="menuitem" itemnum="5" tabindex="-1"><span class="top-page-item">無料お試しを申し込み後にログインする</span></a></li>
<                     <li role="none"><a href=/k/ja/start/more_information.html role="menuitem" itemnum="6" tabindex="-1"><span class="top-page-item">Kintoneをもっと知りたくなったら</span></a></li>
568,569d565
<                     <li role="none"><a href=/k/ja/trouble_shooting/disk_data.html role="menuitem" itemnum="9" tabindex="-1"><span class="top-page-item">ディスク容量／データ容量に関する質問</span></a></li>
<                     <li role="none"><a href=/k/ja/trouble_shooting/developer.html role="menuitem" itemnum="10" tabindex="-1"><span class="top-page-item">APIを使用した開発に関する質問</span></a></li>
571d566
<                     <li role="none"><a href=/k/ja/trouble_shooting/trial.html role="menuitem" itemnum="12" tabindex="-1"><span class="top-page-item">30日間無料お試しに関する質問</span></a></li>
```

#### 中国向けヘルプサイトのトップページの差分

```sh
$ diff cn-before.html cn-after.html
154,155d153
<                     <li role="none"><a href=/k/ja/start/login_started.html role="menuitem" itemnum="5" tabindex="-1"><span class="top-page-item">無料お試しを申し込み後にログインする</span></a></li>
<                     <li role="none"><a href=/k/ja/start/more_information.html role="menuitem" itemnum="6" tabindex="-1"><span class="top-page-item">kintoneをもっと知りたくなったら</span></a></li>
393d390
<                     <li role="none"><a href=/k/ja/admin/support_inquiry.html role="menuitem" itemnum="9" tabindex="-1"><span class="top-page-item">カスタマーサポートに問い合わせる</span></a></li>
431,433d427
<                     <li role="none"><a href=/k/ja/trouble_shooting/developer.html role="menuitem" itemnum="10" tabindex="-1"><span class="top-page-item">APIを使用した開発に関する質問</span></a></li>
<                     <li role="none"><a href=/k/ja/trouble_shooting/disk_storage.html role="menuitem" itemnum="11" tabindex="-1"><span class="top-page-item">ディスク容量に関する質問</span></a></li>
<                     <li role="none"><a href=/k/ja/trouble_shooting/trial.html role="menuitem" itemnum="12" tabindex="-1"><span class="top-page-item">30日間無料お試しに関する質問</span></a></li>
```

### 懸念点

今回の修正を施したことによるその他の変更として、ドロップダウンリスト内の `li` 要素に付与される属性 `itemnum` の値が連番じゃなくなる点が確認されている。（昇順にはなっている。）もしこの変更が許容できない場合は、`range` の中でページの表示をスキップするのではなく、予め表示すべきページの Slice を作成することで回避可能である。

なお、連番じゃなくなることで影響を受けうる箇所として [`moveItemFocusByKeydown` 関数](https://github.com/CybozuDocs/hugo-template/blob/651991bfe354f8cf128381c72f6980c68a4ad9b2/static/javascripts/toppage2.js#L91)が存在する。しかし、これは本タスク着手時点で既に壊れていそうなので、佐々木としてはこの変更を許容し、プログラムの簡潔さを優先してよいのではないかと考えている。