### PR TITLE
Kintone-Localize-Team #333: WOVN による機械翻訳の免責文のリンクを表示する

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -27,78 +27,85 @@
     <div id="shield"></div>
     <header id="header" class="header {{$hedclass}}">
         <div id="head" class="header-wrap">
-        {{- $langlen := len $.AllTranslations }}
-        {{- $baselang := "" }}
-        {{- if ne $langlen 0 }}
-            {{- $baselang = printf "%s/" $.Lang }}
-        {{- end }}
-            <div class="logo-wrap">
-        {{- if and (not .IsHome) (eq $templateversion "2") -}}
-                <button id="tree-switch-mobile" class="tree-switch-mobile">
-                    <i class="fas fa-bars" aria-hidden="true"></i>
-                </button>
-        {{- end }}
-                <h1>
-        {{- $baseLink := printf "%s%s/" $base $.Lang }}
-                    <a class="logo-link" href="{{$baseLink}}">
-        {{- if or (eq .Site.Params.product "kintone") (eq $.Site.Params.TargetRegion "US") }}
-            {{- $alt := printf "%s %s" $.Site.Params.product_name $.Site.Params.help}}
-                        <img class="logo-img" src="{{$base}}{{ $.Site.Params.logo }}" alt="{{$alt}}" title="{{$alt}}">
-        {{- else }}
-            {{- $title := printf "%s %s" ($.Scratch.Get "sitename") $.Site.Params.help }}
-            {{- if eq $.Site.Params.preview_site true }}
-                {{- $title = $.Site.Params.product_name }}
+        <div class="left-item">
+            {{- $langlen := len $.AllTranslations }}
+            {{- $baselang := "" }}
+            {{- if ne $langlen 0 }}
+                {{- $baselang = printf "%s/" $.Lang }}
             {{- end }}
-                        <span class="logo-title">{{$title}}</span>
-        {{- end }}
-                    </a>
-                </h1>
-            </div>
-
-        {{- $glang := $.Lang}}
-        {{- $disp_sbox := true }}
-        {{- if eq .Params.type "search_result" }}
-            {{- $disp_sbox = false }}
-        {{- else if and .IsHome (eq $v2_prod true) }}
-            {{- $disp_sbox = false }}
-        {{- else if eq .Params.type "gr6/home" }}
-            {{- $disp_sbox = false }}
-        {{- else if eq $.Site.Params.preview_site true }}
-            {{- $disp_sbox = false }}
-        {{- end }}
-
-        {{- if eq $disp_sbox true }}
-          {{- if eq $templateversion "2" -}}
-            {{ partial "searchbox" . }}
-          {{- else }}
-            {{- if eq $glang "zh" }}
-                {{- $glang = "zh-CN" }}
-            {{- else if eq $glang "zh-tw" }}
-                {{- $glang = "zh-TW" }}
+                <div class="logo-wrap">
+            {{- if and (not .IsHome) (eq $templateversion "2") -}}
+                    <button id="tree-switch-mobile" class="tree-switch-mobile">
+                        <i class="fas fa-bars" aria-hidden="true"></i>
+                    </button>
             {{- end }}
-            {{- $u := urls.Parse $.Site.BaseURL }}
-            <div id="search" class="search-wrap">
-                <form id="searchBox_form" action="{{ "" | relURL }}{{.Lang}}/search_result.html" onsubmit='if(document.getElementById("headerSearchBox_input").value==""){return false;}' role="search" >
-                    <div class="searchbox">
-                        <input type="search" name="q" id="headerSearchBox_input" class="search-input home-search-input" role="searchbox" aria-label='{{i18n "search_word"}}' placeholder='{{i18n "Enter_keywords"}}'>
-                        <button type="submit" class="search-submit" data-disable-with="" aria-label='{{i18n "search"}}'></button>
-            {{- if ne .Site.Params.google_search true }}
-                        <input type="hidden" name="ct" value="{{ .Site.Params.search_all }}">
+                    <h1>
+            {{- $baseLink := printf "%s%s/" $base $.Lang }}
+                        <a class="logo-link" href="{{$baseLink}}">
+            {{- if or (eq .Site.Params.product "kintone") (eq $.Site.Params.TargetRegion "US") }}
+                {{- $alt := printf "%s %s" $.Site.Params.product_name $.Site.Params.help}}
+                            <img class="logo-img" src="{{$base}}{{ $.Site.Params.logo }}" alt="{{$alt}}" title="{{$alt}}">
+            {{- else }}
+                {{- $title := printf "%s %s" ($.Scratch.Get "sitename") $.Site.Params.help }}
+                {{- if eq $.Site.Params.preview_site true }}
+                    {{- $title = $.Site.Params.product_name }}
+                {{- end }}
+                            <span class="logo-title">{{$title}}</span>
             {{- end }}
-                    </div>
-                </form>
-            </div>
+                        </a>
+                    </h1>
+                </div>
+        </div>
 
-            {{- if eq .Site.Params.google_search true }}
-            <script src="https://www.gstatic.com/prose/brand.js" targetId="headerSearchBox_input" hl="{{$glang}}"></script>
+        <div class="right-item">
+            {{- $glang := $.Lang}}
+            {{- $disp_sbox := true }}
+            {{- if eq .Params.type "search_result" }}
+                {{- $disp_sbox = false }}
+            {{- else if and .IsHome (eq $v2_prod true) }}
+                {{- $disp_sbox = false }}
+            {{- else if eq .Params.type "gr6/home" }}
+                {{- $disp_sbox = false }}
+            {{- else if eq $.Site.Params.preview_site true }}
+                {{- $disp_sbox = false }}
             {{- end }}
-          {{- end }}
-        {{- end }}
 
-        {{- if or (eq .Site.Params.use_wovn true) (and .IsTranslated (eq .Site.Params.langSelector true)) }}
-            {{ partial "langselector" . }}
-        {{- end}}
+            {{- if eq $disp_sbox true }}
+            {{- if eq $templateversion "2" -}}
+                {{ partial "searchbox" . }}
+            {{- else }}
+                {{- if eq $glang "zh" }}
+                    {{- $glang = "zh-CN" }}
+                {{- else if eq $glang "zh-tw" }}
+                    {{- $glang = "zh-TW" }}
+                {{- end }}
+                {{- $u := urls.Parse $.Site.BaseURL }}
+                <div id="search" class="search-wrap">
+                    <form id="searchBox_form" action="{{ "" | relURL }}{{.Lang}}/search_result.html" onsubmit='if(document.getElementById("headerSearchBox_input").value==""){return false;}' role="search" >
+                        <div class="searchbox">
+                            <input type="search" name="q" id="headerSearchBox_input" class="search-input home-search-input" role="searchbox" aria-label='{{i18n "search_word"}}' placeholder='{{i18n "Enter_keywords"}}'>
+                            <button type="submit" class="search-submit" data-disable-with="" aria-label='{{i18n "search"}}'></button>
+                {{- if ne .Site.Params.google_search true }}
+                            <input type="hidden" name="ct" value="{{ .Site.Params.search_all }}">
+                {{- end }}
+                        </div>
+                    </form>
+                </div>
 
+                {{- if eq .Site.Params.google_search true }}
+                <script src="https://www.gstatic.com/prose/brand.js" targetId="headerSearchBox_input" hl="{{$glang}}"></script>
+                {{- end }}
+            {{- end }}
+            {{- end }}
+
+            {{- if or (eq .Site.Params.use_wovn true) (and .IsTranslated (eq .Site.Params.langSelector true)) }}
+                {{ partial "langselector" . }}
+            {{- end}}
+
+            {{- if .Site.Params.use_wovn }}
+                <a class="ai-translation-disclaimer" href="https://dummy.invalid">
+                    AI翻訳の免責
+                </a>
+            {{- end}}
         </div>
     </header>
-

--- a/static/stylesheets/application.css
+++ b/static/stylesheets/application.css
@@ -133,6 +133,18 @@ td {
     display: flex;
     justify-content: space-between;
 }
+/* -------------------- end of Header */
+
+/* Left and Right items -------------------- */
+.left-item {}
+.right-item {
+    display: flex;   
+    gap: 10px;
+    padding-right: 10px;
+}
+/* -------------------- end of Left and Right items */
+
+/* Logo -------------------- */
 .logo-wrap {
     display: flex;
     padding-top: 6px;
@@ -163,8 +175,6 @@ td {
     text-decoration: none;
     cursor: pointer;
 }
-
-/* -------------------- end of Header */
 
 
 /* Searchbox --------------------*/
@@ -299,6 +309,14 @@ li .lang-title {
     background-color: #0d7b91;
 }
 /* -------------------- end of Language selector */
+
+/* AI translation disclaimer -------------------------------------- */
+.ai-translation-disclaimer {
+    display: flex;
+    align-items: center;
+}
+/* -------------------- end of AI translation disclaimer */
+
 .page-pad {
     height: 94px;
 }


### PR DESCRIPTION
https://github.com/kintone-private/Kintone-Localize-Team/issues/333

# やったこと

WOVN による機械翻訳の免責文のリンクを表示した。

## 意思決定とその理由

### コンテナ × `display: flex;` による左寄せ

免責文のリンクと従来の言語切り替えボタンは左寄せする要件があったため、まず初めに左寄せ・右寄せコンテナをそれぞれ作り、ロゴは左寄せコンテナに格納し、免責文のリンクと言語切り替えボタンは右寄せコンテナに格納した。その上で、右寄せコンテナに `display: flex;` を適用して要件を実現した。

その他の対応方法として、言語切り替えボタンに `margin-left: auto;` を適用する方法がある。この方法はコンテナで囲む必要がないため変更箇所がより少なくなる。一方で、免責文のリンクの左寄せは言語切り替えボタンが左寄せされることに依存してしまい、CSS 設計的に望ましくない。そのため、今回はコンテナで囲む方法を採用した。

### 垂直方向に対するリンクの中央寄せ

ロゴ中の文字列と言語切り替えボタン中の文字列は垂直方向に中央寄せされているため、これに合わせた。